### PR TITLE
Fix restaurant dashboard order visibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17246,20 +17246,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",


### PR DESCRIPTION
Fetch initial orders, fix SSE event names, and use correct restaurant-specific endpoints for accept/reject to display and update orders on the restaurant dashboard.

The restaurant dashboard was not loading existing orders, was listening to an incorrect SSE event (`order_ready`), and was calling generic order update endpoints instead of restaurant-specific ones for accepting and rejecting orders. This PR addresses these issues to ensure orders appear and update correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-13c81d72-7e2d-45f2-b10f-b39853836cd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13c81d72-7e2d-45f2-b10f-b39853836cd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

